### PR TITLE
Added support for onTap event listener

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,11 @@ class _MyHomePageState extends State<MyHomePage> {
   String countryValue;
   String stateValue;
   String cityValue;
+
+  void displayMsg(msg) {
+    print(msg);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -54,16 +59,19 @@ class _MyHomePageState extends State<MyHomePage> {
                     countryValue = value;
                   });
                 },
+                onCountryTap: () => displayMsg('You\'ve tapped on countries!'),
                 onStateChanged: (value) {
                   setState(() {
                     stateValue = value;
                   });
                 },
+                onStateTap: () => displayMsg('You\'ve tapped on states!'),
                 onCityChanged: (value) {
                   setState(() {
                     cityValue = value;
                   });
                 },
+                onCityTap: () => displayMsg('You\'ve tapped on cities!'),
               ),
               // InkWell(
               //     onTap: () {

--- a/lib/country_state_city_picker.dart
+++ b/lib/country_state_city_picker.dart
@@ -11,6 +11,9 @@ class SelectState extends StatefulWidget {
   final ValueChanged<String> onCountryChanged;
   final ValueChanged<String> onStateChanged;
   final ValueChanged<String> onCityChanged;
+  final VoidCallback? onCountryTap;
+  final VoidCallback? onStateTap;
+  final VoidCallback? onCityTap;
   final TextStyle? style;
   final Color? dropdownColor;
   final InputDecoration decoration;
@@ -25,7 +28,10 @@ class SelectState extends StatefulWidget {
           const InputDecoration(contentPadding: EdgeInsets.all(0.0)),
       this.spacing = 0.0,
       this.style,
-      this.dropdownColor})
+      this.dropdownColor,
+      this.onCountryTap,
+      this.onStateTap,
+      this.onCityTap})
       : super(key: key);
 
   @override
@@ -171,7 +177,9 @@ class _SelectStateState extends State<SelectState> {
                 ),
               );
             }).toList(),
+            // onTap: ,
             onChanged: (value) => _onSelectedCountry(value!),
+            onTap: widget.onCountryTap,
             value: _selectedCountry,
           )),
         ),
@@ -198,6 +206,7 @@ class _SelectStateState extends State<SelectState> {
               );
             }).toList(),
             onChanged: (value) => _onSelectedState(value!),
+            onTap: widget.onStateTap,
             value: _selectedState,
           )),
         ),
@@ -224,6 +233,7 @@ class _SelectStateState extends State<SelectState> {
               );
             }).toList(),
             onChanged: (value) => _onSelectedCity(value!),
+            onTap: widget.onCityTap,
             value: _selectedCity,
           )),
         ),


### PR DESCRIPTION
Allows devs to pass a callback function to the widget via an onTap event listener. An example of how this can be useful is in a scenario where a dev wants to lose focus on a text field when the dropdown button is tapped.